### PR TITLE
Update app.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [⬆️ Deployment](#️-deployment)
 - [💖 Contributing](#-contributing)
 - [🍴 Forking](#-forking)
+- [🎬 Changing the Asset Type](#-changing-the-asset-type)
 - [💰 Pricing Options](#-pricing-options)
   - [Fixed Pricing](#fixed-pricing)
   - [Free Pricing](#free-pricing)
@@ -829,6 +830,29 @@ If you are looking to fork Ocean Market and create your own marketplace, you wil
 - [Forking Ocean Market](https://docs.oceanprotocol.com/building-with-ocean/build-a-marketplace/forking-ocean-market)
 - [Customising your Market](https://docs.oceanprotocol.com/building-with-ocean/build-a-marketplace/customising-your-market)
 - [Deploying your Market](https://docs.oceanprotocol.com/building-with-ocean/build-a-marketplace/deploying-market)
+
+
+## 🎬 Changing the Asset Type
+
+The marketplace currently lists audio files. That is specified by a variable `category`, in the `additionalInformation` field of the NFT metadata. If you would like to change the type of assets submitted and listed in your fork (say, to mp4 videos), instances of the term `audio` need to be changed to your own type of asset in three locations:
+
+- In the file `aquarius.ts` line 53:
+
+```tsx
+  getFilterTerm('metadata.additionalInformation.category', 'audio')
+```
+This specifies which type of asset Aquarius will list in your fork.
+- In the files `_constants.tsx` line 71, and `_types.ts` line 37:
+
+```tsx
+  category:  'audio',
+```
+These specify that new submissions have the `audio` type.
+
+Moreover, you should update the `ACCEPTED_FILE_TYPES` array, in line 11 of `index.tsx`, to include the new type of asset you want to list (e.g. `'video/mp4'`), and the `options` array, in line 68 of `form.json` and line 14 of `index.tsx` to genres that correspond to your type of asset. 
+
+Finally, the consumption of assets is currently handled by the `react-h5-audio-player`
+library. You should change this to an appropriate consumption method for your type of asset (e.g. a video player or video download).
 
 ## 💰 Pricing Options
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   - [Purgatory](#purgatory)
   - [Network Metadata](#network-metadata)
 - [🚀 Web3 Integration](#-web3-integration)
-  - [Create Album](#createalbum)
+  - [Create](#create)
   - [Encrypt](#encrypt)
   - [Publish](#publish)
   - [Set New Metadata](#setnewmetadata)
@@ -291,12 +291,12 @@ Web3 Integration is a critical component of Ocean Marketplace, enabling seamless
 
 The `PublishPage` component in this project is a key part of the data publishing workflow, and it heavily relies on the integration with the Web3 ecosystem. Below, we'll explore the functions and processes involved in this component:
 
-### `createAlbum()`
+### `create()`
 
-The `createAlbum` function is responsible for creating NFTs (Non-Fungible Tokens) and datatokens, as well as defining the pricing schema for the published data. 
+The `create` function is responsible for creating NFTs (Non-Fungible Tokens) and datatokens, as well as defining the pricing schema for the published data. 
 
 ```tsx
-  async function createAlbum(values: FormPublishData): Promise<{
+  async function create(values: FormPublishData): Promise<{
     erc721Address: string
     datatokenAddress: string
   }> {

--- a/app.config.js
+++ b/app.config.js
@@ -7,7 +7,7 @@ module.exports = {
   // return appConfig.metadataCacheUri
   metadataCacheUri:
     process.env.NEXT_PUBLIC_METADATACACHE_URI ||
-    'https://aquarius.waves.oceanprotocol.com',
+    'https://v4.aquarius.oceanprotocol.com',
 
   v3MetadataCacheUri:
     process.env.NEXT_PUBLIC_V3_METADATACACHE_URI ||

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "styled-components": "^5.3.6",
     "swr": "^1.3.0",
     "urql": "^2.2.1",
-    "use-dark-mode": "^2.3.1",
     "web3": "^1.7.4",
     "web3modal": "^1.9.8",
     "yup": "^0.32.11"


### PR DESCRIPTION
Changed NEXT_PUBLIC_METADATACACHE_URI from 'https://aquarius.waves.oceanprotocol.com' to 'https://v4.aquarius.oceanprotocol.com'

Changes proposed in this PR:
The API at https://aquarius.waves.oceanprotocol.com fails to retrieve metadata for new submissions and existing ones. I suggest using v4.aquarius.oceanprotocol.com instead. 

More details:
The showcase dapp at https://waves.oceanprotocol.com/ currently fails to display new submissions (tested on Mumbai) and the API call returns "not found in Elasticsearch". Clicking on "all audio files" in https://waves.oceanprotocol.com/ only displays four results. Using v4.aquarius.oceanprotocol.com, displays 139 results, and the current user's new submissions.

![waves](https://github.com/oceanprotocol/waves/assets/121819295/f8521d39-0903-418c-8c9d-663824ac5271)
![v4](https://github.com/oceanprotocol/waves/assets/121819295/adb1bf66-a597-47ae-9236-12c5447b0504)